### PR TITLE
feat: enable remove article functionality

### DIFF
--- a/llassist.ApiService/Controllers/ArticleController.cs
+++ b/llassist.ApiService/Controllers/ArticleController.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Threading.Tasks;
+using llassist.Common.Models;
+using llassist.ApiService.Services;
+
+namespace llassist.ApiService.Controllers;
+
+/// <summary>
+/// Controller for managing articles within projects
+/// </summary>
+[ApiController]
+[Route("api/project/{projectId}/article")]
+public class ArticleController : ControllerBase
+{
+    private readonly ArticleService _articleService;
+    private readonly ILogger<ArticleController> _logger;
+
+    public ArticleController(ArticleService articleService, ILogger<ArticleController> logger)
+    {
+        _articleService = articleService ?? throw new ArgumentNullException(nameof(articleService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Deletes an article from a project
+    /// </summary>
+    /// <param name="projectId">The ID of the project</param>
+    /// <param name="articleId">The ID of the article to delete</param>
+    /// <returns>NoContent if successful, NotFound if article doesn't exist</returns>
+    [HttpDelete("{articleId}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> DeleteArticle(string projectId, string articleId)
+    {
+        if (!Ulid.TryParse(projectId, out var parsedProjectId) || 
+            !Ulid.TryParse(articleId, out var parsedArticleId))
+        {
+            return BadRequest("Invalid ID format");
+        }
+
+        _logger.LogInformation("Attempting to delete article {ArticleId} from project {ProjectId}", 
+            articleId, projectId);
+
+        var success = await _articleService.DeleteArticleAsync(parsedArticleId);
+        
+        if (!success)
+        {
+            _logger.LogWarning("Article {ArticleId} not found in project {ProjectId}", 
+                articleId, projectId);
+            return NotFound();
+        }
+
+        _logger.LogInformation("Successfully deleted article {ArticleId} from project {ProjectId}", 
+            articleId, projectId);
+        return NoContent();
+    }
+}

--- a/llassist.ApiService/Services/ArticleService.cs
+++ b/llassist.ApiService/Services/ArticleService.cs
@@ -8,11 +8,20 @@ using llassist.Common.Models;
 using llassist.Common.Mappers;
 using llassist.Common.ViewModels;
 using System.Globalization;
+using llassist.ApiService.Repositories.Specifications;
+using llassist.Common;
 
 namespace llassist.ApiService.Services;
 
 public class ArticleService
 {
+    private readonly ICRUDRepository<Ulid, Article, ArticleSearchSpec> _articleRepository;
+
+    public ArticleService(ICRUDRepository<Ulid, Article, ArticleSearchSpec> articleRepository)
+    {
+        _articleRepository = articleRepository;
+    }
+
     public static IList<Article> ReadArticlesFromCsv(TextReader reader, Ulid projectId)
     {
         var csvConfig = new CsvConfiguration(System.Globalization.CultureInfo.InvariantCulture)
@@ -173,5 +182,10 @@ public class ArticleService
         }
 
         return memoryStream.ToArray();
+    }
+
+    public async Task<bool> DeleteArticleAsync(Ulid articleId)
+    {
+        return await _articleRepository.DeleteAsync(articleId);
     }
 }

--- a/llassist.Common/Mappers/ModelMappers.cs
+++ b/llassist.Common/Mappers/ModelMappers.cs
@@ -71,6 +71,7 @@ public class ModelMappers
     {
         return new ArticleViewModel
         {
+            Id = article.Id.ToString(),
             Title = article.Title,
             Authors = article.Authors,
             Year = article.Year,

--- a/llassist.Common/ViewModels/ProjectViewModels.cs
+++ b/llassist.Common/ViewModels/ProjectViewModels.cs
@@ -29,6 +29,7 @@ public class ProjectViewModel
 
 public class ArticleViewModel
 {
+    public string Id { get; set; } = string.Empty;
     public string Title { get; set; } = string.Empty;
     public string Authors { get; set; } = string.Empty;
     public int Year { get; set; } = 0;

--- a/llassist.Tests/ModelMappersTests.cs
+++ b/llassist.Tests/ModelMappersTests.cs
@@ -122,6 +122,7 @@ public class ModelMappersTests
         var result = ModelMappers.ToArticleViewModel(article);
 
         // Assert
+        Assert.Equal(article.Id.ToString(), result.Id);
         Assert.Equal(article.Title, result.Title);
         Assert.Equal(article.Authors, result.Authors);
         Assert.Equal(article.Year, result.Year);

--- a/llassist.Web/ArticleApiClient.cs
+++ b/llassist.Web/ArticleApiClient.cs
@@ -1,0 +1,15 @@
+public class ArticleApiClient
+{
+    private readonly HttpClient _httpClient;
+
+    public ArticleApiClient(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+    }
+
+    public async Task DeleteArticleAsync(string projectId, string articleId)
+    {
+        var response = await _httpClient.DeleteAsync($"api/project/{projectId}/article/{articleId}");
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/llassist.Web/Components/Pages/Projects/ProjectList.razor
+++ b/llassist.Web/Components/Pages/Projects/ProjectList.razor
@@ -1,6 +1,7 @@
 ﻿@page "/project-list"
 @rendermode InteractiveServer
 @inject ProjectApiClient ProjectApiClient
+@inject ArticleApiClient ArticleApiClient
 @inject NavigationManager Navigation
 @inject IJSRuntime JSRuntime
 
@@ -79,6 +80,7 @@ else
                 <th style="width: 10%">Year</th>
                 <th>Abstract</th>
                 <th style="width: 100px" class="text-center">Must Read</th>
+                <th style="width: 50px" class="text-center">Action</th>
             </tr>
         </thead>
         <tbody>
@@ -97,6 +99,13 @@ else
                         <div class="must-read-indicator @(article.MustRead ? "must-read-true" : "must-read-false")">
                             @(article.MustRead ? "Yes" : "No")
                         </div>
+                    </td>
+                    <td class="text-center">
+                        <button class="btn btn-danger"
+                                @onclick="() => DeleteArticle(selectedProjectId, article.Id)" 
+                                @onclick:stopPropagation="true">
+                            Delete
+                        </button>
                     </td>
                 </tr>
             }
@@ -304,5 +313,11 @@ else if (!string.IsNullOrEmpty(selectedProjectId))
                 await JSRuntime.InvokeVoidAsync("downloadFileFromStream", fileName, Convert.ToBase64String(fileBytes));
             }
         }
+    }
+
+    private async Task DeleteArticle(string projectId, string articleId)
+    {
+        await ArticleApiClient.DeleteArticleAsync(projectId, articleId);
+        await LoadProjectDetails();
     }
 }

--- a/llassist.Web/Program.cs
+++ b/llassist.Web/Program.cs
@@ -18,7 +18,7 @@ internal partial class Program
         // Register HttpClient for API services
         builder.Services.AddHttpClient<ProjectApiClient>(client => client.BaseAddress = new Uri("http+https://apiservice"));
         builder.Services.AddHttpClient<AppSettingApiClient>(client => client.BaseAddress = new Uri("http+https://apiservice"));
-
+        builder.Services.AddHttpClient<ArticleApiClient>(client => client.BaseAddress = new Uri("http+https://apiservice"));
         var app = builder.Build();
 
         if (!app.Environment.IsDevelopment())


### PR DESCRIPTION
This pull request includes significant changes to the `llassist.ApiService` and `llassist.Web` projects, primarily focused on adding the functionality to delete articles from a project. The most important changes include the addition of a new `ArticleController`, modifications to the `ArticleService`, and updates to the web client and UI components to support the new delete functionality.

### API Enhancements:

* [`llassist.ApiService/Controllers/ArticleController.cs`](diffhunk://#diff-e029c8faa3d9a6526b8d7558043ea235c4d44a2091d35a571a7e64c9b631f1b0R1-R62): Added a new controller `ArticleController` with a `DeleteArticle` method to handle HTTP DELETE requests for deleting articles from a project.
* [`llassist.ApiService/Services/ArticleService.cs`](diffhunk://#diff-cbd6b2db1eedd960569312a5b460cc93b0679cdec3de33f04fa8a7a3df4c5b4eR186-R190): Introduced a new method `DeleteArticleAsync` to handle the deletion of articles from the repository.

### Exception Handling:

* [`llassist.ApiService/Program.cs`](diffhunk://#diff-40818100b5106996df3cd89724d4b97d5952ef96ec982bf947a950acb2b4db28L91-R111): Enhanced the global exception handler to return a standardized JSON response for unexpected errors.

### Data Model and Mapping:

* [`llassist.Common/Mappers/ModelMappers.cs`](diffhunk://#diff-2cba9c29a05a71135bc7936d258e535eeb60dc22f80daf3cc72c6c1b55ff2f6eR74): Updated the `ToArticleViewModel` method to include the `Id` property in the `ArticleViewModel`.
* [`llassist.Common/ViewModels/ProjectViewModels.cs`](diffhunk://#diff-ba600c1701d28a4904f1b54a78e7530476e69d07439fadcffd58bc1978610d7aR32): Added the `Id` property to the `ArticleViewModel` class.
* [`llassist.Tests/ModelMappersTests.cs`](diffhunk://#diff-485131096883d82e51c3a8d6bfa60e3d1ec476bfc6bd47f9f356f4a93b4b0aebR125): Added a test assertion to verify that the `Id` property is correctly mapped in `ToArticleViewModel`.

### Web Client and UI:

* [`llassist.Web/ArticleApiClient.cs`](diffhunk://#diff-82859041c454adf635c45b630759b4f8fcec4c1b438e6243617b6ae28e8adf5fR1-R15): Created a new `ArticleApiClient` class with a `DeleteArticleAsync` method to call the API for deleting articles.
* [`llassist.Web/Components/Pages/Projects/ProjectList.razor`](diffhunk://#diff-dbda77b09957a8aef16caa4c439ae1882799f27f8e907b61b6b5d68df6e85830R103-R109): Updated the project list UI to include a delete button for each article and added the `DeleteArticle` method to handle the delete action. [[1]](diffhunk://#diff-dbda77b09957a8aef16caa4c439ae1882799f27f8e907b61b6b5d68df6e85830R103-R109) [[2]](diffhunk://#diff-dbda77b09957a8aef16caa4c439ae1882799f27f8e907b61b6b5d68df6e85830R317-R322)
* [`llassist.Web/Program.cs`](diffhunk://#diff-b83a8fd55b5bd4050174343a79e16880021c7d85a475c7a213e885d76c631947L21-R21): Registered the `ArticleApiClient` with the HTTP client factory.